### PR TITLE
Increase Queue maxworkers to 2

### DIFF
--- a/config/app_queue.php
+++ b/config/app_queue.php
@@ -23,7 +23,7 @@ return [
         'multiserver' => false,
 
         // set this to a limit that can work with your memory limits and alike, 0 => no limit
-        'maxworkers' => 1,
+        'maxworkers' => 2,
 
         // instruct a Workerprocess quit when there are no more tasks for it to execute (true = exit, false = keep running)
         'exitwhennothingtodo' => false,


### PR DESCRIPTION
When we start running a worker, it actually takes one or two seconds for the worker to effectively start. Because of this, when we try to run the next worker, the previous worker is still working and we cannot run the new one. To prevent this, we need to allow an additional worker to run, just to transition between the old and new worker.