### PR TITLE
Reword "use new design" setting

### DIFF
--- a/src/Template/User/settings.ctp
+++ b/src/Template/User/settings.ctp
@@ -325,13 +325,13 @@ $this->set('title_for_layout', $this->Pages->formatTitle(__('Settings')));
                 <md-checkbox
                     ng-false-value="0"
                     ng-true-value="1"
-                    ng-model="useNewDesign"
-                    ng-init="useNewDesign = <?= $useNewDesign ?>"
+                    ng-model="useOldDesign"
+                    ng-init="useOldDesign = <?= !$useNewDesign ?>"
                     class="md-primary">
                 </md-checkbox>
                 <p><?php echo __(
-                    'Display sentences with the new design. '.
-                    'Note that some features are not yet implemented in this new design but are coming soon.'
+                    'Display sentences with the old design. '.
+                    'Note that the old design will be removed at some point.'
                 ) ?></p>
                 <div ng-hide="true">
                 <?php


### PR DESCRIPTION
I removed the part that says "Note that some features are not yet implemented in this new design..." because it is no longer true. Since we plan to remove the old design, this option will disappear at some point, so I left it in the "experimental" option, but reworded it so that "using the old design" is now considered as experimental.